### PR TITLE
v3.6.0

### DIFF
--- a/Nhl.Api.Extensions.Microsoft.DependencyInjection/Nhl.Api.Extensions.Microsoft.DependencyInjection.csproj
+++ b/Nhl.Api.Extensions.Microsoft.DependencyInjection/Nhl.Api.Extensions.Microsoft.DependencyInjection.csproj
@@ -5,7 +5,7 @@
 		<Description>The official unofficial Nhl.Api Microsoft .NET dependency injection extension library</Description>
 		<Copyright>Copyright (c) 2024 Andre Fischbacher</Copyright>
 		<Authors>Andre Fischbacher</Authors>
-		<Version>3.5.0</Version>
+		<Version>3.6.0</Version>
 		<PackageProjectUrl>https://github.com/Afischbacher/Nhl.Api.Extensions.Microsoft.DependencyInjection</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Afischbacher/Nhl.Api.Extensions.Microsoft.DependencyInjection</RepositoryUrl>
 		<Description>The Microsoft .NET dependency injection library extension for the official unofficial .NET NHL API</Description>
@@ -41,6 +41,6 @@
 	</Target>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-		<PackageReference Include="Nhl.Api" Version="3.5.0" />
+		<PackageReference Include="Nhl.Api" Version="3.6.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updated the project version in `Nhl.Api.Extensions.Microsoft.DependencyInjection.csproj` from `3.5.0` to `3.6.0`. Also updated the `PackageReference` for the `Nhl.Api` package to version `3.6.0` to ensure compatibility and include new features or bug fixes.